### PR TITLE
ci: fix publish ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,6 @@ jobs:
         run: |
           git config --global user.name "${{ github.event.pusher.name }}"
           git config --global user.email "${{ github.event.pusher.email }}"
-          git checkout main
           git add latest-stable.json
           git commit -am "Update latest.json"
-          git push
+          git push origin HEAD:main


### PR DESCRIPTION
This PR should fix `publish-to-github` job in release workflow.

Checking out main fails (maybe because only the current commit is checked out, and github doesn't fetch branches?)
https://github.com/elk-zone/elk-native/actions/runs/3932925265/jobs/6726295434#step:11:12

As suggested by git itself, the solution would be to run `git push origin HEAD:<name of remote branch>` because we are on a detached head and git doesn't know what branch to push to.
https://github.com/elk-zone/elk-native/actions/runs/3932757776/jobs/6725903851#step:11:18

Even if the head wasn't detached, I belive the push would fail, as `push.autoSetupRemote = true` isn't set.