### PR TITLE
Enable macOSPrivateApi

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -48,6 +48,7 @@
         "timestampUrl": ""
       }
     },
+    "macOSPrivateApi": true,
     "security": {
       "csp": {
         "default-src": "'none'",


### PR DESCRIPTION
According to docs, you must enable [macOSPrivateApi[(https://tauri.app/v1/api/config#tauriconfig.macosprivateapi) in order to set the [windowconfig.transparent](https://tauri.app/v1/api/config#windowconfig.transparent) setting on Mac. 

As the docs call out, it does mean that the app will not be accepted to the app store. 