### PR TITLE
fix: standard keyboard shortcuts

### DIFF
--- a/.changes/default-menu.md
+++ b/.changes/default-menu.md
@@ -1,0 +1,5 @@
+---
+"elk-native": patch
+---
+
+Elk Native now supports standard keyboard shortcurts like Copy, Paste, Cut, and Fullscreen.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,6 +5,7 @@
 
 use env_logger::filter::Builder as FilterBuilder;
 use log::LevelFilter;
+use tauri::Menu;
 #[cfg(debug_assertions)]
 use tauri_plugin_log::fern::colors::ColoredLevelConfig;
 use tauri_plugin_log::{Builder as LogPluginBuilder, LogTarget};
@@ -35,6 +36,7 @@ fn main() {
         .plugin(log_plugin)
         .plugin(StorePluginBuilder::default().build())
         .plugin(WindowStateBuilder::default().build())
+        .menu(Menu::os_default("Elk"))
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
This adds the default menu, so the standard keyboard shortcuts like Copy/Paste/Cut etc. work within elk-native